### PR TITLE
setting form can not handle multiple mirrors anymore

### DIFF
--- a/src/main/resources/static/mirror-repository-hook.js
+++ b/src/main/resources/static/mirror-repository-hook.js
@@ -6,7 +6,7 @@ define('et/hook/mirror', ['jquery', 'exports'], function ($, exports) {
                 var currIndex, index = 0, name, html;
 
                 // Determine the current index from the last password input
-                name = $('div.html-contents input:password').last().attr("name");
+                name = $('div.et-mirror-contents input:password').last().attr("name");
 
                 if (name && name.length >= 8) {
                     currIndex = parseInt(name.substring(8));

--- a/src/main/resources/static/mirror-repository-hook.js
+++ b/src/main/resources/static/mirror-repository-hook.js
@@ -6,7 +6,7 @@ define('et/hook/mirror', ['jquery', 'exports'], function ($, exports) {
                 var currIndex, index = 0, name, html;
 
                 // Determine the current index from the last password input
-                name = $('div.hook-config-contents input:password').last().attr("name");
+                name = $('div.html-contents input:password').last().attr("name");
 
                 if (name && name.length >= 8) {
                     currIndex = parseInt(name.substring(8));

--- a/src/main/resources/static/mirror-repository-hook.soy
+++ b/src/main/resources/static/mirror-repository-hook.soy
@@ -6,31 +6,33 @@
  */
 {template .view}
 
-    // Always add one subview
-    {call .subview data="all"}
-        {param index: 0 /}
-    {/call}
+    <div class="et-mirror-contents">
+      // Always add one subview
+      {call .subview data="all"}
+          {param index: 0 /}
+      {/call}
 
-    // Add additional mirrors, up to 10 total
-    {foreach $index in [1, 2, 3, 4, 5, 6, 7, 8, 9]}
-        {if $config['mirrorRepoUrl' + $index] or $config['username' + $index]}
-            {call .subview data="all"}
-              {param index: $index /}
-            {/call}
-        {/if}
-    {/foreach}
+      // Add additional mirrors, up to 10 total
+      {foreach $index in [1, 2, 3, 4, 5, 6, 7, 8, 9]}
+          {if $config['mirrorRepoUrl' + $index] or $config['username' + $index]}
+              {call .subview data="all"}
+                {param index: $index /}
+              {/call}
+          {/if}
+      {/foreach}
 
-    // Button to add additional mirrors
-    {call aui.buttons.button}
-        {param id: 'et-add-button' /}
-        {param text: 'Add Mirror' /}
-        {param extraAttributes: 'type=button' /}
-    {/call}
+      // Button to add additional mirrors
+      {call aui.buttons.button}
+          {param id: 'et-add-button' /}
+          {param text: 'Add Mirror' /}
+          {param extraAttributes: 'type=button' /}
+      {/call}
 
-    // Call init method with subview callback
-    <script>
-        require("et/hook/mirror").init(com.englishtown.bitbucket.hook.subview, aui.buttons.button);
-    </script>
+      // Call init method with subview callback
+      <script>
+          require("et/hook/mirror").init(com.englishtown.bitbucket.hook.subview, aui.buttons.button);
+      </script>
+    </div>
 {/template}
 
 /**


### PR DESCRIPTION
Bitbucket has probably changed the name of the enclosing div of the hook setting form. The div with the class `hook-config` does not exist anymore. So the index for new subviews is always 0. Probably for the div the new class name is called `html-contents`.

We have observed this problem with a Bitbucket server v5.5.1.