### PR TITLE
Project level mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ https://bitbucket.org/atlassian/aui/src/master/src/soy/form.soy
 
 The plugin can be found on the Atlassian Marketplace here:
 https://marketplace.atlassian.com/plugins/com.englishtown.stash-hook-mirror
+
+Plugin properties in bitbucket.properties in file, located in the shared folder of server home directory:
+
+`plugin.com.englishtown.stash-hook-mirror.push.attempts=5
+plugin.com.englishtown.stash-hook-mirror.push.threads=3
+plugin.com.englishtown.stash-hook-mirror.push.timeout=120`
+

--- a/src/main/java/com/englishtown/bitbucket/hook/MirrorBucketProcessor.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/MirrorBucketProcessor.java
@@ -49,6 +49,7 @@ public class MirrorBucketProcessor implements BucketProcessor<MirrorRequest> {
         this.securityService = securityService;
 
         timeout = Duration.ofSeconds(propertiesService.getPluginProperty(PROP_TIMEOUT, 120L));
+        log.debug(PROP_TIMEOUT+": "+timeout.getSeconds());
     }
 
     @Override

--- a/src/main/java/com/englishtown/bitbucket/hook/MirrorRepositoryHook.java
+++ b/src/main/java/com/englishtown/bitbucket/hook/MirrorRepositoryHook.java
@@ -78,7 +78,9 @@ public class MirrorRepositoryHook implements PostRepositoryHook<RepositoryHookRe
     private BucketedExecutor<MirrorRequest> createPushExecutor(){
         logger.debug("MirrorRepositoryHook: initialize pushExecutor");
         int attempts = propertiesService.getPluginProperty(PROP_ATTEMPTS, 5);
+        logger.debug(PROP_ATTEMPTS+": "+attempts);
         int threads = propertiesService.getPluginProperty(PROP_THREADS, 3);
+        logger.debug(PROP_THREADS+": "+threads);
         return concurrencyService.getBucketedExecutor(getClass().getSimpleName(),
                 new BucketedExecutorSettings.Builder<>(MirrorRequest::toString, pushProcessor)
                         .batchSize(Integer.MAX_VALUE) // Coalesce all requests into a single push

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -35,5 +35,9 @@
             <view>com.englishtown.bitbucket.hook.view</view>
             <directory location="/static/"/>
         </config-form>
+        <scopes>
+            <scope>project</scope>
+            <scope>repository</scope>
+        </scopes>
     </repository-hook>
 </atlassian-plugin>

--- a/src/main/resources/static/mirror-repository-hook.js
+++ b/src/main/resources/static/mirror-repository-hook.js
@@ -27,8 +27,8 @@ define('et/hook/mirror', ['jquery', 'exports'], function ($, exports) {
         function addRemoveButton() {
             // Select all fieldset groups that don't have a remove button
             var group = $(".et-mirror-group").not(":has(.et-remove-button)");
-            var html = createButton({text: 'Remove', extraClasses: 'et-remove-button add-hook-button', extraAttributes: 'type=button'});
-            group.find('.et-mirror-repo input').after(html);
+            var html = "<div>"+createButton({text: 'Remove', extraClasses: 'et-remove-button add-hook-button', extraAttributes: 'type=button'})+"</div>";
+            group.find('.et-mirror-repo textarea').after(html);
 
             group.find('.et-remove-button').click(function (e) {
                 $(e.currentTarget).parents('.et-mirror-group').remove();

--- a/src/main/resources/static/mirror-repository-hook.soy
+++ b/src/main/resources/static/mirror-repository-hook.soy
@@ -42,7 +42,7 @@
  */
 {template .subview}
     <fieldset class="et-mirror-group">
-        {call aui.form.textField}
+        {call aui.form.textareaField}
             {param id: 'mirrorRepoUrl' + $index /}
             {param value: $config['mirrorRepoUrl' + $index] /}
             {param labelContent}
@@ -51,6 +51,7 @@
             {param isRequired: true /}
             {param descriptionText: getText('mirror-repository-hook.mirrorRepoUrl.description') /}
             {param extraClasses: 'et-mirror-repo' /}
+            {param fieldWidth: 'long' /}
             {param errorTexts: $errors ? $errors['mirrorRepoUrl' + $index] : null /}
         {/call}
         {call aui.form.textField}


### PR DESCRIPTION
We have large project with several thousands repositories. We have remote CI infrastructure on gitlab. To avoid hook configuration at repository level, repository remote url interpolation is introduced. This allows project level hook configuration. Repository hook configuration is inherited from project (I don't know since when it is supported in bitbucket).
Also notice ClassCastException workaround in pushExecutor after each plugin upgrade.
Please review if this makes sense for Your mainstream project.